### PR TITLE
Support `hedgehog-1.1`

### DIFF
--- a/hedgehog-fn.cabal
+++ b/hedgehog-fn.cabal
@@ -32,7 +32,7 @@ library
                      , Hedgehog.Function.Internal
   build-depends:       base >=4.8 && <5
                      , contravariant >=1.4 && <1.6
-                     , hedgehog >=1.0 && <1.1
+                     , hedgehog >=1.0 && <1.2
                      , transformers >=0.4.2 && <0.6
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Confirmed to build when using `allow-newer`.