### PR TITLE
Upgrade hedgehog to 1.7

### DIFF
--- a/hedgehog-fn.cabal
+++ b/hedgehog-fn.cabal
@@ -32,7 +32,7 @@ library
                      , Hedgehog.Function.Internal
   build-depends:       base >=4.8 && <5
                      , contravariant >=1.4 && <1.6
-                     , hedgehog >=1.0 && <1.6
+                     , hedgehog >=1.0 && <1.8
                      , transformers >=0.4.2 && <0.7
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Closes #11 

Also compiled with `hedgehog ==1.6` to check that the `<1.8` version bound was appropriate.